### PR TITLE
Add Backblaze B2 link to homepage

### DIFF
--- a/k8s/apps/homepage.yaml
+++ b/k8s/apps/homepage.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/byeich/homelab
-    targetRevision: main
+    targetRevision: add-backblaze-link
     path: k8s/apps/homepage
   destination:
     server: https://kubernetes.default.svc

--- a/k8s/apps/homepage/configmap.yaml
+++ b/k8s/apps/homepage/configmap.yaml
@@ -76,6 +76,10 @@ data:
             href: http://10.0.0.9
             description: NAS storage
             icon: truenas.png
+        - Backblaze B2:
+            href: https://secure.backblaze.com/b2_buckets.htm
+            description: Offsite backup
+            icon: backblaze.png
 
     - Security:
         - Vaultwarden:


### PR DESCRIPTION
## Summary
- Adds Backblaze B2 to the Homepage dashboard under Files & Storage
- Reverts homepage ArgoCD app targetRevision back to main

## Test plan
- [x] Deployed to cluster via add-backblaze-link branch
- [x] Backblaze B2 link visible on home.bkylab.net