### PR TITLE
add B2 remote state backend for OpenTofu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   yamllint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
 
   tofu:
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.B2_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.B2_APP_KEY }}
     steps:
       - uses: actions/checkout@v6
       - uses: opentofu/setup-opentofu@v2

--- a/proxmox/tofu/main.tf
+++ b/proxmox/tofu/main.tf
@@ -6,7 +6,7 @@ locals {
     node      = var.node_name
     bridge    = var.network_bridge
     rootds    = var.rootfs_datastore
-    tmpl_id   = proxmox_virtual_environment_download_file.debian_lxc.id
+    tmpl_id   = proxmox_download_file.debian_lxc.id
     vm_node   = var.vm_node_name
     vm_bridge = var.vm_network_bridge
     vm_rootds = var.rootfs_datastore
@@ -33,7 +33,7 @@ locals {
 }
 
 # Download LXC Template
-resource "proxmox_virtual_environment_download_file" "debian_lxc" {
+resource "proxmox_download_file" "debian_lxc" {
   node_name    = var.node_name
   content_type = "vztmpl"
   datastore_id = var.template_datastore

--- a/proxmox/tofu/provider.tf
+++ b/proxmox/tofu/provider.tf
@@ -9,6 +9,21 @@ terraform {
       version = "~> 2.0"
     }
   }
+
+  backend "s3" {
+    bucket = "bkylab-tofu-state"
+    key    = "proxmox/tofu/terraform.tfstate"
+    region = "us-east-005"
+
+    endpoints = {
+      s3 = "https://s3.us-east-005.backblazeb2.com"
+    }
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    force_path_style            = true
+  }
 }
 
 provider "proxmox" {

--- a/proxmox/tofu/provider.tf
+++ b/proxmox/tofu/provider.tf
@@ -22,7 +22,7 @@ terraform {
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_region_validation      = true
-    force_path_style            = true
+    use_path_style              = true
   }
 }
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -28,6 +28,36 @@ prompt()  { echo -e "${YELLOW}[INPUT]${NC} $*"; }
 section() { echo -e "\n${GREEN}══════════════════════════════════════${NC}"; echo -e "${GREEN}  $*${NC}"; echo -e "${GREEN}══════════════════════════════════════${NC}"; }
 
 
+section "Step 0: OpenTofu remote state credentials"
+TOFU_ENV_FILE="$HOME/.config/homelab/tofu.env"
+mkdir -p "$HOME/.config/homelab"
+
+if [[ -f "$TOFU_ENV_FILE" ]] && grep -q "AWS_ACCESS_KEY_ID" "$TOFU_ENV_FILE"; then
+  info "B2 credentials already saved at $TOFU_ENV_FILE"
+  # shellcheck source=/dev/null
+  source "$TOFU_ENV_FILE"
+else
+  warn "OpenTofu state is stored in Backblaze B2 (bkylab-tofu-state bucket)."
+  prompt "Enter B2 Key ID for tofu state bucket (or press Enter to skip):"
+  read -r -s B2_KEY_ID
+  if [[ -n "$B2_KEY_ID" ]]; then
+    prompt "Enter B2 Application Key:"
+    read -r -s B2_APP_KEY
+    cat > "$TOFU_ENV_FILE" <<EOF
+export AWS_ACCESS_KEY_ID="$B2_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$B2_APP_KEY"
+EOF
+    chmod 600 "$TOFU_ENV_FILE"
+    # shellcheck source=/dev/null
+    source "$TOFU_ENV_FILE"
+    unset B2_KEY_ID B2_APP_KEY
+    info "Credentials saved to $TOFU_ENV_FILE"
+    info "Add 'source $TOFU_ENV_FILE' to your ~/.zshrc to persist across sessions."
+  else
+    warn "Skipped. Run 'tofu init' manually after exporting AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
+  fi
+fi
+
 section "Step 1: Mac prerequisites"
 if ! command -v brew &>/dev/null; then
   echo -e "${RED}Homebrew not found. Install it first: https://brew.sh${NC}"


### PR DESCRIPTION
## Summary
- Adds S3 backend to `provider.tf` pointing at Backblaze B2 bucket `bkylab-tofu-state` (us-east-005)
- Adds Step 0 to `bootstrap.sh` to prompt for B2 credentials and save to `~/.config/homelab/tofu.env`
- State has already been migrated from local to B2 via `tofu init -migrate-state`

## Test plan
- [x] `tofu state list` returns all 11 resources when B2 credentials are exported
- [x] `bootstrap.sh` Step 0 prompts for credentials and saves to `~/.config/homelab/tofu.env`