### PR TITLE
add securityContext hardening to all app deployments

### DIFF
--- a/k8s/apps/cloudflared/deployment.yaml
+++ b/k8s/apps/cloudflared/deployment.yaml
@@ -18,6 +18,14 @@ spec:
       containers:
         - name: cloudflared
           image: cloudflare/cloudflared:2026.3.0
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 10m

--- a/k8s/apps/homepage/deployment.yaml
+++ b/k8s/apps/homepage/deployment.yaml
@@ -20,7 +20,6 @@ spec:
         - name: homepage
           image: ghcr.io/gethomepage/homepage:v1.12.3
           securityContext:
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/k8s/apps/homepage/deployment.yaml
+++ b/k8s/apps/homepage/deployment.yaml
@@ -19,6 +19,13 @@ spec:
       containers:
         - name: homepage
           image: ghcr.io/gethomepage/homepage:v1.12.3
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 10m

--- a/k8s/apps/immich/machine-learning.yaml
+++ b/k8s/apps/immich/machine-learning.yaml
@@ -18,6 +18,12 @@ spec:
       containers:
         - name: machine-learning
           image: ghcr.io/immich-app/immich-machine-learning:v2.7.5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 500m

--- a/k8s/apps/immich/postgres.yaml
+++ b/k8s/apps/immich/postgres.yaml
@@ -18,6 +18,14 @@ spec:
       containers:
         - name: postgres
           image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 999
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/k8s/apps/immich/redis.yaml
+++ b/k8s/apps/immich/redis.yaml
@@ -17,6 +17,7 @@ spec:
         - name: redis
           image: docker.io/valkey/valkey:9
           securityContext:
+            runAsUser: 999
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/k8s/apps/immich/redis.yaml
+++ b/k8s/apps/immich/redis.yaml
@@ -17,7 +17,6 @@ spec:
         - name: redis
           image: docker.io/valkey/valkey:9
           securityContext:
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/k8s/apps/immich/redis.yaml
+++ b/k8s/apps/immich/redis.yaml
@@ -16,6 +16,13 @@ spec:
       containers:
         - name: redis
           image: docker.io/valkey/valkey:9
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 10m

--- a/k8s/apps/immich/server.yaml
+++ b/k8s/apps/immich/server.yaml
@@ -17,6 +17,12 @@ spec:
       containers:
         - name: immich-server
           image: ghcr.io/immich-app/immich-server:v2.7.5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 750m

--- a/k8s/apps/obsidian/deployment.yaml
+++ b/k8s/apps/obsidian/deployment.yaml
@@ -21,6 +21,14 @@ spec:
       containers:
         - name: couchdb
           image: couchdb:3.5.1
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 5984
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 10m

--- a/k8s/apps/vaultwarden/deployment.yaml
+++ b/k8s/apps/vaultwarden/deployment.yaml
@@ -19,6 +19,12 @@ spec:
       containers:
         - name: vaultwarden
           image: vaultwarden/server:1.35.8
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary
- Adds `securityContext` to all 8 app deployments: cloudflared, homepage, obsidian, vaultwarden, immich-server, immich-machine-learning, immich-postgres, immich-redis
- All containers: `allowPrivilegeEscalation: false`, `capabilities: drop: [ALL]`, `seccompProfile: RuntimeDefault`
- `runAsNonRoot: true` applied where the image supports it (cloudflared, obsidian/couchdb, immich-postgres)
- `runAsUser: 999` on immich-redis to bypass valkey's `setresuid` call (drop:ALL removes SETUID; starting as the target user avoids the capability requirement entirely)
- `readOnlyRootFilesystem: true` on cloudflared only (other images write to their root FS at runtime)
- Skipped `runAsNonRoot` on homepage (non-numeric USER in image), vaultwarden, immich-server, immich-ml (all run as root)

## ArgoCD targeting
- This branch: `targetRevision: main` on all app YAMLs — merging restores all apps to main automatically
- Main branch currently points to `cluster-security-updates` for live testing; all 8 pods confirmed Running with 0 restarts before opening this PR

## Test plan
- [x] All 8 deployments running and healthy (`kubectl get pods -n immich`, `-n homepage`, `-n cloudflared`, `-n vaultwarden`, `-n obsidian`)
- [x] Fixed `CreateContainerConfigError` on homepage (non-numeric USER — removed runAsNonRoot)
- [x] Fixed `CrashLoopBackOff` on immich-redis (setresuid failed — added runAsUser:999 to bypass setuid call)
- [x] 0 container restarts across all affected pods