### PR TITLE
Add homelab diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # homelab
-Repo for IaC/configuration of homelab
+
+Personal homelab managed as code. Two Proxmox nodes running a 8-node k3s cluster, with TrueNAS for storage and ArgoCD for GitOps. Infrastructure provisioned with OpenTofu + Ansible; workloads deployed via ArgoCD App-of-Apps targeting this repo.
+
+```mermaid
+graph LR
+    internet(["Internet"]) -->|"*.bkylab.net"| cf["Cloudflare\ntunnel · DNS"]
+    gh["GitHub\n+ Renovate"] -->|"ArgoCD sync"| cluster
+
+    subgraph home["Home Network · 10.0.0.0/24"]
+        pihole["Pi-hole · .53\nlocal DNS"]
+        truenas["TrueNAS · .9\nNFS · backup target"]
+        subgraph proxmox["Proxmox: homelab + homelab2"]
+            cluster["k3s Cluster\n3 control · 5 workers\nvaultwarden · immich · homepage\nobsidian · grafana · cloudflared"]
+        end
+    end
+
+    b2["Backblaze B2\nbackups · tofu state"]
+
+    cf -->|"tunnel"| cluster
+    pihole -->|"→ 10.0.0.60"| cluster
+    cluster -->|"NFS · backups"| truenas
+    truenas -->|"rclone crypt"| b2
+```
+
+See [docs/architecture.md](docs/architecture.md) for detailed infrastructure, traffic flow, GitOps pipeline, and storage diagrams.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homelab
 
-Personal homelab managed as code. Two Proxmox nodes running a 8-node k3s cluster, with TrueNAS for storage and ArgoCD for GitOps. Infrastructure provisioned with OpenTofu + Ansible; workloads deployed via ArgoCD App-of-Apps targeting this repo.
+Personal homelab managed as code. Two Proxmox nodes running an 8-node k3s cluster, with TrueNAS for storage and ArgoCD for GitOps. Infrastructure provisioned with OpenTofu + Ansible; workloads deployed via ArgoCD App-of-Apps targeting this repo.
 
 ```mermaid
 flowchart LR

--- a/README.md
+++ b/README.md
@@ -3,24 +3,37 @@
 Personal homelab managed as code. Two Proxmox nodes running a 8-node k3s cluster, with TrueNAS for storage and ArgoCD for GitOps. Infrastructure provisioned with OpenTofu + Ansible; workloads deployed via ArgoCD App-of-Apps targeting this repo.
 
 ```mermaid
-graph LR
-    internet(["Internet"]) -->|"*.bkylab.net"| cf["Cloudflare\ntunnel · DNS"]
-    gh["GitHub\n+ Renovate"] -->|"ArgoCD sync"| cluster
+flowchart LR
+    internet(["🌐 Internet"])
+    gh(["⚙️ GitHub + Renovate"])
 
     subgraph home["Home Network · 10.0.0.0/24"]
-        pihole["Pi-hole · .53\nlocal DNS"]
-        truenas["TrueNAS · .9\nNFS · backup target"]
-        subgraph proxmox["Proxmox: homelab + homelab2"]
+        pihole["Pi-hole\n10.0.0.53"]
+        truenas[("TrueNAS\n10.0.0.9")]
+        subgraph proxmox["Proxmox · homelab + homelab2"]
             cluster["k3s Cluster\n3 control · 5 workers\nvaultwarden · immich · homepage\nobsidian · grafana · cloudflared"]
         end
     end
 
-    b2["Backblaze B2\nbackups · tofu state"]
+    cf["☁️ Cloudflare\ntunnel · DNS"]
+    b2["☁️ Backblaze B2\nbackups · state"]
 
+    internet -->|"*.bkylab.net"| cf
     cf -->|"tunnel"| cluster
-    pihole -->|"→ 10.0.0.60"| cluster
+    gh -->|"ArgoCD sync"| cluster
+    pihole -.->|"→ 10.0.0.60"| cluster
     cluster -->|"NFS · backups"| truenas
     truenas -->|"rclone crypt"| b2
+
+    classDef k8s     fill:#326ce5,stroke:#fff,stroke-width:2px,color:#fff
+    classDef storage fill:#e8a838,stroke:#fff,stroke-width:2px,color:#fff
+    classDef dns     fill:#e85d04,stroke:#fff,stroke-width:2px,color:#fff
+    classDef ext     fill:#f5f5f5,stroke:#bbb,color:#444
+
+    class cluster k8s
+    class truenas storage
+    class pihole dns
+    class cf,b2,gh,internet ext
 ```
 
 See [docs/architecture.md](docs/architecture.md) for detailed infrastructure, traffic flow, GitOps pipeline, and storage diagrams.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ flowchart LR
     classDef storage fill:#e8a838,stroke:#fff,stroke-width:2px,color:#fff
     classDef dns     fill:#e85d04,stroke:#fff,stroke-width:2px,color:#fff
     classDef ext     fill:#f5f5f5,stroke:#bbb,color:#444
+    classDef gitops  fill:#24292e,stroke:#fff,stroke-width:2px,color:#fff
 
     class cluster k8s
     class truenas storage
     class pihole dns
-    class cf,b2,gh,internet ext
+    class cf,b2,internet ext
+    class gh gitops
 ```
 
 See [docs/architecture.md](docs/architecture.md) for detailed infrastructure, traffic flow, GitOps pipeline, and storage diagrams.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,113 @@
+# Architecture
+
+## Physical Infrastructure
+
+Two Proxmox hosts and a separate TrueNAS storage server on a flat 10.0.0.0/24 home network. OpenTofu provisions all VMs declaratively; Ansible configures them. `homelab2` is the primary node (runs control plane + most workers); `homelab` hosts the two workers with large Longhorn disks.
+
+```mermaid
+graph TB
+    subgraph prox2["Proxmox: homelab2"]
+        pihole["Pi-hole LXC · 10.0.0.53"]
+        ctrl["k3s-control-1/2/3\n10.0.0.60 – 62  ·  4 GB RAM  ·  2 vCPU"]
+        wrk123["k3s-worker-1/2/3\n10.0.0.70 – 72  ·  4 GB RAM  ·  50 GB Longhorn disk"]
+    end
+
+    subgraph prox1["Proxmox: homelab"]
+        wrk45["k3s-worker-4/5\n10.0.0.73 – 74  ·  4 GB RAM  ·  100 GB Longhorn disk"]
+    end
+
+    truenas["TrueNAS SCALE · 10.0.0.9\nbigtank pool  (2 × 12 TB mirror + hot spare)\nFast pool  (SSD)"]
+```
+
+## Network & Traffic Flow
+
+External services are exposed through a Cloudflare tunnel — no ports opened on the router. The Cloudflared pod inside the cluster maintains an outbound tunnel to Cloudflare, which proxies `*.bkylab.net` traffic inbound. Internal access uses Pi-hole DNS records that resolve `*.bkylab.net` to `10.0.0.60` (the first control node), hitting Traefik directly without leaving the LAN.
+
+```mermaid
+graph LR
+    user(["User"])
+
+    subgraph ext["External"]
+        cf["Cloudflare\nDNS + CDN"]
+    end
+
+    subgraph home["Home Network"]
+        pihole["Pi-hole · 10.0.0.53"]
+
+        subgraph cluster["k3s Cluster"]
+            cfpod["cloudflared pod\n(persistent tunnel)"]
+            traefik["Traefik\n(ingress controller)"]
+            svc["Service pods"]
+        end
+    end
+
+    user -->|"*.bkylab.net  (public)"| cf
+    cf <-->|"tunnel"| cfpod
+    cfpod --> traefik
+
+    user -->|"*.bkylab.net  (LAN)"| pihole
+    pihole -->|"→ 10.0.0.60"| traefik
+
+    traefik --> svc
+```
+
+**Public services** (Cloudflare tunnel): `home.bkylab.net`, `obsidian.bkylab.net`, `grafana.bkylab.net`
+
+**LAN-only** (Pi-hole DNS only): `argocd.bkylab.net`, `longhorn.bkylab.net`
+
+## GitOps Pipeline
+
+All Kubernetes workloads are managed via ArgoCD using the App-of-Apps pattern. ArgoCD polls the `main` branch of this repo; changes merged to `main` are automatically synced to the cluster within ~3 minutes. Feature work targets the `dev` branch — ArgoCD apps point at `dev` for active development, with `main` as the stable target.
+
+Renovate runs as a GitHub App and opens automated PRs for dependency bumps (Helm charts, container images, GitHub Actions). Version pinning rules in `renovate.json` block major upgrades for Longhorn and PostgreSQL, which require manual upgrade procedures.
+
+```mermaid
+graph LR
+    dev(["Dev machine"])
+
+    dev -->|"git push dev/main"| gh["GitHub"]
+    renovate["Renovate bot"] -->|"dep bump PRs"| gh
+
+    gh --> ci["CI pipeline\nyamllint · tofu validate\nansible-lint · kubeconform"]
+    ci -->|"merge"| repo["main branch"]
+
+    repo -->|"polls every 3 min"| argo["ArgoCD"]
+    argo -->|"sync"| k3s["k3s cluster"]
+    argo -->|"sync · health alerts"| tg["📱 Telegram"]
+```
+
+CI runs on every push and PR:
+- **yamllint** — YAML syntax and style on `k8s/` and Ansible files
+- **tofu validate + fmt** — Terraform syntax and formatting
+- **ansible-lint** — Ansible best practices (37 violations fixed to reach clean baseline)
+- **kubeconform** — validates Kubernetes manifests against upstream schemas (strict mode)
+
+## Storage Architecture
+
+Storage is layered: Longhorn provides distributed block storage for most workloads; Immich photos use a direct NFS mount to TrueNAS to avoid copying 100+ GB through the cluster. Longhorn takes daily volume backups to TrueNAS over NFS, and TrueNAS syncs everything offsite to Backblaze B2 via rclone with client-side encryption.
+
+```mermaid
+graph TB
+    subgraph cluster["k3s Cluster"]
+        apps["Stateful app pods\nvaultwarden · obsidian · grafana · postgres"]
+        immich["Immich\n(server + machine learning)"]
+        lh["Longhorn\n2 replicas · daily backup · weekly snapshot\nlonghorn-retain StorageClass"]
+    end
+
+    truenas["TrueNAS SCALE · 10.0.0.9\n/mnt/bigtank/longhorn-backups\n/mnt/bigtank/immich/photos"]
+    b2["Backblaze B2\n(rclone crypt — filenames encrypted)"]
+    tofu["OpenTofu\n(local machine)"]
+
+    apps -->|"PVC  RWO block"| lh
+    immich -->|"PVC  RWO block  (DB + cache)"| lh
+    immich -->|"photos  NFS RWX\n(bypasses Longhorn)"| truenas
+    lh -->|"volume backups  NFS"| truenas
+    truenas -->|"Cloud Sync task\n--fast-list"| b2
+    tofu -->|"remote state\nS3-compatible backend"| b2
+```
+
+**StorageClass notes:**
+- `longhorn-retain` — used by Vaultwarden, Immich-postgres, Obsidian. `reclaimPolicy: Retain` so PVCs survive accidental namespace deletion.
+- `longhorn` (Delete) — used by monitoring stack (Prometheus, Grafana, Alertmanager). Acceptable to lose and reprovision.
+
+**B2 cost note:** `--fast-list` enabled on the TrueNAS Cloud Sync task to batch LIST operations into Class B calls, avoiding the 2,500/day Class C free-tier cap on large datasets.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,9 +11,9 @@ flowchart TB
         ctrl1["k3s-control-1"]
         ctrl2["k3s-control-2"]
         ctrl3["k3s-control-3"]
-        wrk1["k3s-worker-1"]
-        wrk2["k3s-worker-2"]
-        wrk3["k3s-worker-3"]
+        wrk1["k3s-worker-1\n50 GB disk"]
+        wrk2["k3s-worker-2\n50 GB disk"]
+        wrk3["k3s-worker-3\n50 GB disk"]
     end
 
     subgraph prox1["Proxmox · homelab"]
@@ -59,6 +59,8 @@ flowchart TB
 | `k3s-worker-4` | `10.0.0.73` | Worker | homelab | 2 | 4 GB | 100 GB |
 | `k3s-worker-5` | `10.0.0.74` | Worker | homelab | 2 | 4 GB | 100 GB |
 | TrueNAS | `10.0.0.9` | NAS / backup target | bare metal | — | — | 2×12 TB mirror + spare |
+
+> **HA note:** Workers currently connect to `ctrl1`'s API server directly (`10.0.0.60:6443`). etcd tolerates losing one control plane node, but workers lose API connectivity if ctrl1 goes down. A kube-vip VIP in front of all three control plane nodes is a planned improvement.
 
 ## k3s Cluster Services
 
@@ -144,8 +146,9 @@ flowchart LR
     cf <-->|"persistent tunnel"| cfpod
     cfpod --> traefik
 
-    user -->|"LAN  *.bkylab.net"| pihole
-    pihole -.->|"→ 10.0.0.60"| traefik
+    user -->|"LAN DNS lookup"| pihole
+    pihole -.->|"resolves → 10.0.0.60"| user
+    user -->|"→ 10.0.0.60 direct"| traefik
 
     traefik --> svc
 
@@ -174,6 +177,7 @@ flowchart LR
 
     subgraph gh["GitHub"]
         ci["CI\nyamllint · tofu validate\nansible-lint · kubeconform"]
+        devbr["dev branch"]
         repo["main branch"]
     end
 
@@ -182,8 +186,9 @@ flowchart LR
         workloads["Workloads"]
     end
 
-    dev -->|"git push"| gh
-    renovate -->|"dep bump PRs"| gh
+    dev -->|"git push"| devbr
+    renovate -->|"dep bump PRs"| repo
+    devbr -->|"PR + merge"| repo
     ci --> repo
     repo -->|"polls · ~3 min"| argo
     argo --> workloads
@@ -194,7 +199,7 @@ flowchart LR
     classDef msg     fill:#2ca5e0,stroke:#fff,stroke-width:2px,color:#fff
 
     class argo,workloads k8s
-    class dev,renovate,tg ext
+    class dev,renovate ext
     class tg msg
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,8 +206,8 @@ flowchart LR
 CI runs on every push and PR:
 - **yamllint** — YAML syntax and style on `k8s/` and Ansible files
 - **tofu validate + fmt** — Terraform syntax and formatting
-- **ansible-lint** — Ansible best practices (37 violations fixed to reach clean baseline)
-- **kubeconform** — validates Kubernetes manifests against upstream schemas (strict mode)
+- **ansible-lint** — Ansible best practices
+- **kubeconform** — validates Kubernetes manifests against upstream schemas
 
 ## Storage Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,11 @@ flowchart TB
         ls[("Storage")]:::nas
     end
 
+    ctrl1 <-->|"etcd"| ctrl2
+    ctrl2 <-->|"etcd"| ctrl3
+    ctrl1 <-->|"etcd"| ctrl3
+    wrk1 & wrk2 & wrk3 & wrk4 & wrk5 -->|"join"| ctrl1
+
     classDef control fill:#326ce5,stroke:#fff,stroke-width:2px,color:#fff
     classDef worker  fill:#6ea6e0,stroke:#fff,stroke-width:2px,color:#fff
     classDef dns     fill:#e85d04,stroke:#fff,stroke-width:2px,color:#fff
@@ -95,6 +100,7 @@ flowchart TB
     vw & obs --> lh
     immich --> lh
     prom & grafana --> lh
+    prom -.->|"scrapes metrics"| vw & immich & home & obs
 
     immich -.->|"photos NFS  (bypasses Longhorn)"| truenas
     lh -.->|"volume backups"| truenas
@@ -200,7 +206,7 @@ CI runs on every push and PR:
 
 ## Storage Architecture
 
-Storage is layered: Longhorn provides distributed block storage for most workloads; Immich photos use a direct NFS mount to TrueNAS to avoid routing 100+ GB through the cluster. Longhorn takes daily volume backups to TrueNAS over NFS, and TrueNAS syncs everything offsite to Backblaze B2 via rclone with client-side encryption.
+Storage is layered: Longhorn provides distributed block storage for most workloads; Immich photos use a direct NFS mount to TrueNAS to avoid routing bulk media storage through the cluster. Longhorn takes daily volume backups to TrueNAS over NFS, and TrueNAS syncs everything offsite to Backblaze B2 via rclone with client-side encryption.
 
 ```mermaid
 flowchart TB

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,78 +2,194 @@
 
 ## Physical Infrastructure
 
-Two Proxmox hosts and a separate TrueNAS storage server on a flat 10.0.0.0/24 home network. OpenTofu provisions all VMs declaratively; Ansible configures them. `homelab2` is the primary node (runs control plane + most workers); `homelab` hosts the two workers with large Longhorn disks.
+Two Proxmox hosts and a separate TrueNAS storage server on a flat `10.0.0.0/24` home network. OpenTofu provisions all VMs declaratively; Ansible configures them. `homelab2` is the primary node (runs control plane + most workers); `homelab` hosts the two workers with large Longhorn disks.
 
 ```mermaid
-graph TB
-    subgraph prox2["Proxmox: homelab2"]
-        pihole["Pi-hole LXC · 10.0.0.53"]
-        ctrl["k3s-control-1/2/3\n10.0.0.60 – 62  ·  4 GB RAM  ·  2 vCPU"]
-        wrk123["k3s-worker-1/2/3\n10.0.0.70 – 72  ·  4 GB RAM  ·  50 GB Longhorn disk"]
+flowchart TB
+    subgraph prox2["Proxmox · homelab2"]
+        pihole["pihole\nLXC"]
+        ctrl1["k3s-control-1"]
+        ctrl2["k3s-control-2"]
+        ctrl3["k3s-control-3"]
+        wrk1["k3s-worker-1"]
+        wrk2["k3s-worker-2"]
+        wrk3["k3s-worker-3"]
     end
 
-    subgraph prox1["Proxmox: homelab"]
-        wrk45["k3s-worker-4/5\n10.0.0.73 – 74  ·  4 GB RAM  ·  100 GB Longhorn disk"]
+    subgraph prox1["Proxmox · homelab"]
+        wrk4["k3s-worker-4\n100 GB disk"]
+        wrk5["k3s-worker-5\n100 GB disk"]
     end
 
-    truenas["TrueNAS SCALE · 10.0.0.9\nbigtank pool  (2 × 12 TB mirror + hot spare)\nFast pool  (SSD)"]
+    truenas[("TrueNAS SCALE\n10.0.0.9")]
+
+    subgraph legend["Legend"]
+        direction LR
+        lc["Control plane"]:::control
+        lw["Worker"]:::worker
+        ld["DNS"]:::dns
+        ls[("Storage")]:::nas
+    end
+
+    classDef control fill:#326ce5,stroke:#fff,stroke-width:2px,color:#fff
+    classDef worker  fill:#6ea6e0,stroke:#fff,stroke-width:2px,color:#fff
+    classDef dns     fill:#e85d04,stroke:#fff,stroke-width:2px,color:#fff
+    classDef nas     fill:#e8a838,stroke:#fff,stroke-width:2px,color:#fff
+
+    class ctrl1,ctrl2,ctrl3,lc control
+    class wrk1,wrk2,wrk3,wrk4,wrk5,lw worker
+    class pihole,ld dns
+    class truenas,ls nas
+```
+
+| Host | IP | Role | Proxmox node | vCPU | RAM | Longhorn disk |
+|---|---|---|---|---|---|---|
+| `pihole` | `10.0.0.53` | Pi-hole DNS (LXC) | homelab2 | 1 | 512 MB | — |
+| `k3s-control-1` | `10.0.0.60` | Control plane | homelab2 | 2 | 4 GB | 50 GB |
+| `k3s-control-2` | `10.0.0.61` | Control plane | homelab2 | 2 | 4 GB | 50 GB |
+| `k3s-control-3` | `10.0.0.62` | Control plane | homelab2 | 2 | 4 GB | 50 GB |
+| `k3s-worker-1` | `10.0.0.70` | Worker | homelab2 | 2 | 4 GB | 50 GB |
+| `k3s-worker-2` | `10.0.0.71` | Worker | homelab2 | 2 | 4 GB | 50 GB |
+| `k3s-worker-3` | `10.0.0.72` | Worker | homelab2 | 2 | 4 GB | 50 GB |
+| `k3s-worker-4` | `10.0.0.73` | Worker | homelab | 2 | 4 GB | 100 GB |
+| `k3s-worker-5` | `10.0.0.74` | Worker | homelab | 2 | 4 GB | 100 GB |
+| TrueNAS | `10.0.0.9` | NAS / backup target | bare metal | — | — | 2×12 TB mirror + spare |
+
+## k3s Cluster Services
+
+Workloads are managed by ArgoCD via GitOps. Traefik is the ingress controller; Cloudflared maintains an outbound tunnel to Cloudflare so external traffic never requires open router ports. Longhorn provides distributed block storage; Immich photos bypass Longhorn and mount directly from TrueNAS over NFS.
+
+```mermaid
+flowchart TB
+    cf(["☁️ Cloudflare"])
+    tg(["📱 Telegram"])
+
+    subgraph cluster["k3s Cluster"]
+        subgraph ingress["Ingress"]
+            cfpod["cloudflared"]
+            traefik["Traefik"]
+        end
+
+        subgraph apps["Applications"]
+            vw["Vaultwarden\npassword manager"]
+            immich["Immich\nphoto library"]
+            home["Homepage\ndashboard"]
+            obs["Obsidian / CouchDB\nnotes sync"]
+        end
+
+        subgraph observability["Observability"]
+            prom[("Prometheus")]
+            grafana["Grafana"]
+            alert["Alertmanager"]
+        end
+
+        lh[("Longhorn\n2 replicas · daily backup")]
+    end
+
+    truenas[("TrueNAS NFS\n10.0.0.9")]
+
+    cf <-->|"tunnel"| cfpod
+    cfpod --> traefik
+    traefik --> vw & immich & home & obs & grafana
+
+    vw & obs --> lh
+    immich --> lh
+    prom & grafana --> lh
+
+    immich -.->|"photos NFS  (bypasses Longhorn)"| truenas
+    lh -.->|"volume backups"| truenas
+
+    alert -->|"alerts"| tg
+
+    classDef k8s     fill:#326ce5,stroke:#fff,stroke-width:2px,color:#fff
+    classDef storage fill:#e8a838,stroke:#fff,stroke-width:2px,color:#fff
+    classDef ext     fill:#f5f5f5,stroke:#bbb,color:#444
+    classDef msg     fill:#2ca5e0,stroke:#fff,stroke-width:2px,color:#fff
+
+    class cfpod,traefik,vw,immich,home,obs,prom,grafana,alert k8s
+    class lh,truenas storage
+    class cf ext
+    class tg msg
 ```
 
 ## Network & Traffic Flow
 
-External services are exposed through a Cloudflare tunnel — no ports opened on the router. The Cloudflared pod inside the cluster maintains an outbound tunnel to Cloudflare, which proxies `*.bkylab.net` traffic inbound. Internal access uses Pi-hole DNS records that resolve `*.bkylab.net` to `10.0.0.60` (the first control node), hitting Traefik directly without leaving the LAN.
+External services are exposed through a Cloudflare tunnel — no ports opened on the router. The Cloudflared pod maintains a persistent outbound connection; Cloudflare proxies `*.bkylab.net` traffic inbound through it. Internal access uses Pi-hole DNS records that resolve `*.bkylab.net` to `10.0.0.60`, hitting Traefik directly without leaving the LAN.
 
 ```mermaid
-graph LR
-    user(["User"])
+flowchart LR
+    user(["👤 User"])
 
     subgraph ext["External"]
-        cf["Cloudflare\nDNS + CDN"]
+        cf["☁️ Cloudflare"]
     end
 
-    subgraph home["Home Network"]
-        pihole["Pi-hole · 10.0.0.53"]
+    subgraph home["Home Network · 10.0.0.0/24"]
+        pihole["Pi-hole\n10.0.0.53"]
 
         subgraph cluster["k3s Cluster"]
-            cfpod["cloudflared pod\n(persistent tunnel)"]
-            traefik["Traefik\n(ingress controller)"]
+            cfpod["cloudflared\n(tunnel)"]
+            traefik["Traefik\n(ingress)"]
             svc["Service pods"]
         end
     end
 
-    user -->|"*.bkylab.net  (public)"| cf
-    cf <-->|"tunnel"| cfpod
+    user -->|"public  *.bkylab.net"| cf
+    cf <-->|"persistent tunnel"| cfpod
     cfpod --> traefik
 
-    user -->|"*.bkylab.net  (LAN)"| pihole
-    pihole -->|"→ 10.0.0.60"| traefik
+    user -->|"LAN  *.bkylab.net"| pihole
+    pihole -.->|"→ 10.0.0.60"| traefik
 
     traefik --> svc
+
+    classDef k8s fill:#326ce5,stroke:#fff,stroke-width:2px,color:#fff
+    classDef dns fill:#e85d04,stroke:#fff,stroke-width:2px,color:#fff
+    classDef ext fill:#f5f5f5,stroke:#bbb,color:#444
+
+    class cfpod,traefik,svc k8s
+    class pihole dns
+    class cf ext
 ```
 
-**Public services** (Cloudflare tunnel): `home.bkylab.net`, `obsidian.bkylab.net`, `grafana.bkylab.net`
+**Public** (Cloudflare tunnel): `home.bkylab.net`, `obsidian.bkylab.net`, `grafana.bkylab.net`
 
-**LAN-only** (Pi-hole DNS only): `argocd.bkylab.net`, `longhorn.bkylab.net`
+**LAN-only** (Pi-hole DNS → `10.0.0.60`): `argocd.bkylab.net`, `longhorn.bkylab.net`
 
 ## GitOps Pipeline
 
-All Kubernetes workloads are managed via ArgoCD using the App-of-Apps pattern. ArgoCD polls the `main` branch of this repo; changes merged to `main` are automatically synced to the cluster within ~3 minutes. Feature work targets the `dev` branch — ArgoCD apps point at `dev` for active development, with `main` as the stable target.
-
-Renovate runs as a GitHub App and opens automated PRs for dependency bumps (Helm charts, container images, GitHub Actions). Version pinning rules in `renovate.json` block major upgrades for Longhorn and PostgreSQL, which require manual upgrade procedures.
+ArgoCD polls the `main` branch and syncs any drift within ~3 minutes. All feature work goes to `dev` first — ArgoCD apps target `dev` during development. Renovate runs as a GitHub App and opens automated PRs for Helm chart, container image, and GitHub Actions version bumps; `renovate.json` blocks major upgrades for Longhorn and PostgreSQL which need manual procedures.
 
 ```mermaid
-graph LR
-    dev(["Dev machine"])
+flowchart LR
+    dev(["💻 Dev machine"])
+    renovate(["🤖 Renovate"])
+    tg(["📱 Telegram"])
 
-    dev -->|"git push dev/main"| gh["GitHub"]
-    renovate["Renovate bot"] -->|"dep bump PRs"| gh
+    subgraph gh["GitHub"]
+        ci["CI\nyamllint · tofu validate\nansible-lint · kubeconform"]
+        repo["main branch"]
+    end
 
-    gh --> ci["CI pipeline\nyamllint · tofu validate\nansible-lint · kubeconform"]
-    ci -->|"merge"| repo["main branch"]
+    subgraph cluster["k3s Cluster"]
+        argo["ArgoCD"]
+        workloads["Workloads"]
+    end
 
-    repo -->|"polls every 3 min"| argo["ArgoCD"]
-    argo -->|"sync"| k3s["k3s cluster"]
-    argo -->|"sync · health alerts"| tg["📱 Telegram"]
+    dev -->|"git push"| gh
+    renovate -->|"dep bump PRs"| gh
+    ci --> repo
+    repo -->|"polls · ~3 min"| argo
+    argo --> workloads
+    argo -->|"sync · health alerts"| tg
+
+    classDef k8s     fill:#326ce5,stroke:#fff,stroke-width:2px,color:#fff
+    classDef ext     fill:#f5f5f5,stroke:#bbb,color:#444
+    classDef msg     fill:#2ca5e0,stroke:#fff,stroke-width:2px,color:#fff
+
+    class argo,workloads k8s
+    class dev,renovate,tg ext
+    class tg msg
 ```
 
 CI runs on every push and PR:
@@ -84,30 +200,38 @@ CI runs on every push and PR:
 
 ## Storage Architecture
 
-Storage is layered: Longhorn provides distributed block storage for most workloads; Immich photos use a direct NFS mount to TrueNAS to avoid copying 100+ GB through the cluster. Longhorn takes daily volume backups to TrueNAS over NFS, and TrueNAS syncs everything offsite to Backblaze B2 via rclone with client-side encryption.
+Storage is layered: Longhorn provides distributed block storage for most workloads; Immich photos use a direct NFS mount to TrueNAS to avoid routing 100+ GB through the cluster. Longhorn takes daily volume backups to TrueNAS over NFS, and TrueNAS syncs everything offsite to Backblaze B2 via rclone with client-side encryption.
 
 ```mermaid
-graph TB
+flowchart TB
     subgraph cluster["k3s Cluster"]
-        apps["Stateful app pods\nvaultwarden · obsidian · grafana · postgres"]
-        immich["Immich\n(server + machine learning)"]
-        lh["Longhorn\n2 replicas · daily backup · weekly snapshot\nlonghorn-retain StorageClass"]
+        apps["Stateful apps\nvaultwarden · obsidian · grafana · postgres"]
+        immich["Immich"]
+        lh[("Longhorn\n2 replicas · daily backup · weekly snapshot")]
     end
 
-    truenas["TrueNAS SCALE · 10.0.0.9\n/mnt/bigtank/longhorn-backups\n/mnt/bigtank/immich/photos"]
-    b2["Backblaze B2\n(rclone crypt — filenames encrypted)"]
-    tofu["OpenTofu\n(local machine)"]
+    truenas[("TrueNAS · 10.0.0.9\nbigtank pool")]
+    b2["☁️ Backblaze B2\n(rclone crypt)"]
+    tofu(["💻 OpenTofu"])
 
-    apps -->|"PVC  RWO block"| lh
-    immich -->|"PVC  RWO block  (DB + cache)"| lh
-    immich -->|"photos  NFS RWX\n(bypasses Longhorn)"| truenas
-    lh -->|"volume backups  NFS"| truenas
-    truenas -->|"Cloud Sync task\n--fast-list"| b2
-    tofu -->|"remote state\nS3-compatible backend"| b2
+    apps    -->|"PVC  RWO block"| lh
+    immich  -->|"PVC  RWO block  (DB · cache)"| lh
+    immich  -.->|"photos  NFS RWX"| truenas
+    lh      -->|"volume backups  NFS"| truenas
+    truenas -->|"Cloud Sync  --fast-list"| b2
+    tofu    -->|"remote state  S3"| b2
+
+    classDef k8s     fill:#326ce5,stroke:#fff,stroke-width:2px,color:#fff
+    classDef storage fill:#e8a838,stroke:#fff,stroke-width:2px,color:#fff
+    classDef ext     fill:#f5f5f5,stroke:#bbb,color:#444
+
+    class apps,immich k8s
+    class lh,truenas storage
+    class b2,tofu ext
 ```
 
-**StorageClass notes:**
-- `longhorn-retain` — used by Vaultwarden, Immich-postgres, Obsidian. `reclaimPolicy: Retain` so PVCs survive accidental namespace deletion.
-- `longhorn` (Delete) — used by monitoring stack (Prometheus, Grafana, Alertmanager). Acceptable to lose and reprovision.
+**StorageClass:**
+- `longhorn-retain` — Vaultwarden, Immich-postgres, Obsidian. `reclaimPolicy: Retain` survives accidental namespace deletion.
+- `longhorn` (Delete) — monitoring stack. Acceptable to reprovision on cluster rebuild.
 
-**B2 cost note:** `--fast-list` enabled on the TrueNAS Cloud Sync task to batch LIST operations into Class B calls, avoiding the 2,500/day Class C free-tier cap on large datasets.
+**B2 cost:** `--fast-list` batches LIST calls into Class B operations, staying under the 2,500/day Class C free-tier cap.

--- a/docs/runbook-disaster-recovery.md
+++ b/docs/runbook-disaster-recovery.md
@@ -17,10 +17,10 @@ Longhorn volume restores (Step 7) are the main variable — large volumes over a
 
 Before starting, verify access to:
 
-- **Bitwarden** (bitwarden.com or mobile app — NOT vaultwarden.bkylab.net, which is the service being rebuilt) — contains the sealed-secrets key backup, rclone B2 crypt passphrase/salt, Cloudflare tunnel credentials.json, and all service passwords
+- **Bitwarden** (bitwarden.com or mobile app — NOT vaultwarden.bkylab.net, which is the service being rebuilt) contains the sealed-secrets key backup, rclone B2 crypt passphrase/salt, Cloudflare tunnel credentials.json, and all service passwords
 - **B2 credentials** — `~/.config/homelab/tofu.env` (or retrieve B2 Key ID + App Key from Bitwarden for tofu remote state)
 - **SSH keys** — `~/.ssh/homelab` (Pi-hole LXC) and `~/.ssh/k3s_cluster` (k3s VMs). Run `./scripts/generate-keys.sh` if missing
-- **CLI tools** — `kubectl`, `helm`, `tofu`, `rclone`, `kubeseal` (`brew install kubeseal` if missing — needed for Step 5 smoke test)
+- **CLI tools** — `kubectl`, `helm`, `tofu`, `rclone`, `kubeseal` (`brew install kubeseal` if missing, needed for Step 5 smoke test)
 - **Proxmox** running with VM templates on both nodes (ID 9000 on homelab2, ID 9001 on homelab)
 - **TrueNAS** running with NFS shares accessible (Longhorn backup target + Immich photos NFS)
 
@@ -37,7 +37,7 @@ Before starting, verify access to:
 
 ## Step 0: Restore from B2 (only if TrueNAS lost)
 
-> Skip this step if TrueNAS is running — Longhorn reads the NFS backup share directly and the rclone passphrase is not needed.
+> Skip this step if TrueNAS is running since Longhorn reads the NFS backup share directly and the rclone passphrase is not needed.
 
 TrueNAS itself must be rebuilt first (OS reinstall, pool import, datasets recreated) before restoring data to it. Once the OS and pool are up:
 
@@ -71,7 +71,7 @@ After TrueNAS NFS shares are restored, continue from Step 1.
 
 ```bash
 cd proxmox/tofu
-source ~/.config/homelab/tofu.env   # B2 credentials for remote state
+source ~/.config/homelab/tofu.env    # B2 credentials for remote state
 tofu init                            # required on fresh checkout or new machine
 tofu apply
 ```
@@ -82,7 +82,7 @@ tofu apply
 
 ## Step 2: Install Pi-hole DNS
 
-Install Pi-hole **before** k3s. The k3s VMs are configured to use 10.0.0.53 as their DNS resolver — if Pi-hole isn't running when k3s pulls images in Step 3, DNS resolution fails.
+Install Pi-hole **before** k3s. The k3s VMs are configured to use 10.0.0.53 as their DNS resolver. If Pi-hole isn't running when k3s pulls images in Step 3, DNS resolution fails.
 
 ```bash
 cd proxmox/ansible
@@ -92,7 +92,7 @@ cd proxmox/ansible
 
 Verify Pi-hole is resolving before proceeding:
 ```bash
-dig @10.0.0.53 google.com +short   # should return an IP, not an error
+dig @10.0.0.53 google.com +short   # should return an IP
 ```
 
 Pi-hole at 10.0.0.53. Internal hostnames (`argocd.bkylab.net`, `longhorn.bkylab.net`) resolve via Pi-hole → 10.0.0.60 (Traefik).
@@ -122,16 +122,16 @@ ssh -i ~/.ssh/k3s_cluster -o StrictHostKeyChecking=no debian@10.0.0.60 \
 chmod 600 ~/.kube/k3s-homelab.yaml
 export KUBECONFIG=~/.kube/k3s-homelab.yaml
 
-kubectl get nodes   # all 8 nodes should be Ready
+kubectl get nodes   # all nodes should be Ready
 ```
 
 ---
 
-## Step 4: Install infrastructure (Helm charts)
+## Step 4: Install infrastructure
 
 This is a rebuild — sealed secrets are already committed to git. Install the Helm charts directly, then restore the sealed-secrets key before letting ArgoCD sync.
 
-> **Why not `k3s_bootstrap.yml`?** The README rebuild path uses that playbook, but it runs all the way through Helm installs → sealed-secrets apply → App-of-Apps in one shot. For DR, the sealed-secrets key must be manually restored (Step 5) between Helm install and App-of-Apps — there's no safe place to inject that step inside the playbook. Do the Helm installs manually here, restore the key in Step 5, then apply App-of-Apps in Step 6.
+> **Why not `k3s_bootstrap.yml`?** The README rebuild path uses that playbook, but it runs all the way through Helm installs → sealed-secrets apply → App-of-Apps in one shot. For DR, the sealed-secrets key must be manually restored (Step 5) between Helm install and App-of-Apps, since there's no safe place to inject that step inside the playbook. Do the Helm installs manually here, restore the key in Step 5, then apply App-of-Apps in Step 6.
 
 ```bash
 export KUBECONFIG=~/.kube/k3s-homelab.yaml
@@ -164,7 +164,7 @@ helm upgrade --install sealed-secrets sealed-secrets/sealed-secrets \
   --wait
 ```
 
-Version numbers are pinned in `scripts/bootstrap.sh` — use those as the source of truth if this runbook is out of date.
+Version numbers are pinned in `scripts/bootstrap.sh`. Use those as the source of truth if this runbook is out of date.
 
 **Do NOT apply App-of-Apps yet.** Continue to Step 5.
 
@@ -172,12 +172,12 @@ Version numbers are pinned in `scripts/bootstrap.sh` — use those as the source
 
 ## Step 5: CRITICAL — Restore sealed-secrets key
 
-The sealed-secrets controller auto-generates a new key pair on first startup. If ArgoCD syncs before you replace it with the original backed-up key, every SealedSecret in git will fail to decrypt — the controller returns an error and creates no Secret at all, so every service starts with missing credentials.
+The sealed-secrets controller auto-generates a new key pair on first startup. If ArgoCD syncs before you replace it with the original backed-up key, every SealedSecret in git will fail to decrypt and the controller returns an error and creates no Secret at all, so every service starts with missing credentials.
 
 ```bash
 # 1. Get the backed-up key YAML from Bitwarden
 #    Bitwarden → Secure Notes → "sealed-secrets-keykwwrf full YAML"
-#    Save it locally — do NOT commit this file
+#    Save it locally, do NOT commit this file
 vim ~/sealed-secrets-keykwwrf.yaml
 
 # 2. Delete the auto-generated key the controller created on startup


### PR DESCRIPTION
Purpose of this PR is to add in some diagrams explaining my current homelab setup at a higher level from information about the Proxmox nodes, how the data moves in/through the cluster, what services are being ran, etc. 

I took information I have in my notes and found Mermaid to be a great fit for my use case since it's: 
- Github native
- Works with my existing markdown documents
- Lots of examples/support available for more complex diagrams