### PR TITLE
drop storage buckets and add retentionSize

### DIFF
--- a/k8s/bootstrap/monitoring/values.yaml
+++ b/k8s/bootstrap/monitoring/values.yaml
@@ -8,9 +8,17 @@ kubeScheduler:
 kubeProxy:
   enabled: false
 
+kubeApiServer:
+  serviceMonitor:
+    metricRelabelings:
+      - sourceLabels: [__name__]
+        regex: 'apiserver_request_duration_seconds_bucket|apiserver_request_sli_duration_seconds_bucket|etcd_request_duration_seconds_bucket|apiserver_request_body_size_bytes_bucket|apiserver_response_sizes_bucket|apiserver_watch_cache_read_wait_seconds_bucket|apiserver_watch_events_sizes_bucket'
+        action: drop
+
 prometheus:
   prometheusSpec:
     retention: 30d
+    retentionSize: 15GB
     storageSpec:
       volumeClaimTemplate:
         spec:


### PR DESCRIPTION
Prometheus PV was hitting ~86% full (18 days of data in a 20 GB volume) and alerting as expected to fill within 4 days.

Root cause was high cardinality — 335k active series, with ~183k (55%) coming from 7 API server histogram `_bucket` metrics that aren't useful in a homelab context. Dropping them cuts storage from ~0.96 GB/day to ~0.43 GB/day, so 30 days of data fits comfortably at ~13 GB.

Changes:
- Drop the 7 high-cardinality `_bucket` metrics via `kubeApiServer.serviceMonitor.metricRelabelings` — `_count` and `_sum` variants are kept so average latency data is preserved
- Add `retentionSize: 15GB` alongside `retention: 30d` as a safety valve so a future cardinality spike can't fill the disk again

<img width="527" height="627" alt="image" src="https://github.com/user-attachments/assets/55921c4f-165f-4b63-b2b8-2dc51c0cf069" />
