### PR TITLE
kube-vip control plane HA (#28)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ flowchart TB
     ctrl1 <-->|"etcd"| ctrl2
     ctrl2 <-->|"etcd"| ctrl3
     ctrl1 <-->|"etcd"| ctrl3
-    ctrl1 & ctrl2 & ctrl3 -->|"ARP"| vip
+    vip -.->|"backed by"| ctrl1 & ctrl2 & ctrl3
     wrk1 & wrk2 & wrk3 & wrk4 & wrk5 -->|"join"| vip
 
     classDef control fill:#326ce5,stroke:#fff,stroke-width:2px,color:#fff

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,20 +31,25 @@ flowchart TB
         ls[("Storage")]:::nas
     end
 
+    vip["kube-vip VIP\n10.0.0.59"]:::vip
+
     ctrl1 <-->|"etcd"| ctrl2
     ctrl2 <-->|"etcd"| ctrl3
     ctrl1 <-->|"etcd"| ctrl3
-    wrk1 & wrk2 & wrk3 & wrk4 & wrk5 -->|"join"| ctrl1
+    ctrl1 & ctrl2 & ctrl3 -->|"ARP"| vip
+    wrk1 & wrk2 & wrk3 & wrk4 & wrk5 -->|"join"| vip
 
     classDef control fill:#326ce5,stroke:#fff,stroke-width:2px,color:#fff
     classDef worker  fill:#6ea6e0,stroke:#fff,stroke-width:2px,color:#fff
     classDef dns     fill:#e85d04,stroke:#fff,stroke-width:2px,color:#fff
     classDef nas     fill:#e8a838,stroke:#fff,stroke-width:2px,color:#fff
+    classDef vip     fill:#6f42c1,stroke:#fff,stroke-width:2px,color:#fff
 
     class ctrl1,ctrl2,ctrl3,lc control
     class wrk1,wrk2,wrk3,wrk4,wrk5,lw worker
     class pihole,ld dns
     class truenas,ls nas
+    class vip vip
 ```
 
 | Host | IP | Role | Proxmox node | vCPU | RAM | Longhorn disk |
@@ -58,9 +63,10 @@ flowchart TB
 | `k3s-worker-3` | `10.0.0.72` | Worker | homelab2 | 2 | 4 GB | 50 GB |
 | `k3s-worker-4` | `10.0.0.73` | Worker | homelab | 2 | 4 GB | 100 GB |
 | `k3s-worker-5` | `10.0.0.74` | Worker | homelab | 2 | 4 GB | 100 GB |
+| kube-vip VIP | `10.0.0.59` | Control plane VIP (kube-vip ARP) | — | — | — | — |
 | TrueNAS | `10.0.0.9` | NAS / backup target | bare metal | — | — | 2×12 TB mirror + spare |
 
-> **HA note:** Workers currently connect to `ctrl1`'s API server directly (`10.0.0.60:6443`). etcd tolerates losing one control plane node, but workers lose API connectivity if ctrl1 goes down. A kube-vip VIP in front of all three control plane nodes is a planned improvement.
+> **HA:** Workers connect to the kube-vip VIP (`10.0.0.59`) rather than any individual control plane node. kube-vip runs as a DaemonSet on all three control nodes and uses ARP to float the VIP — losing any one control node leaves the API reachable and workers unaffected.
 
 ## k3s Cluster Services
 

--- a/docs/runbook-disaster-recovery.md
+++ b/docs/runbook-disaster-recovery.md
@@ -117,7 +117,7 @@ mkdir -p ~/.kube
 # StrictHostKeyChecking=no required — freshly provisioned VMs have new host keys
 ssh -i ~/.ssh/k3s_cluster -o StrictHostKeyChecking=no debian@10.0.0.60 \
   "sudo cat /etc/rancher/k3s/k3s.yaml" \
-  | sed 's|https://127.0.0.1:6443|https://10.0.0.60:6443|g' \
+  | sed 's|https://127.0.0.1:6443|https://10.0.0.59:6443|g' \
   > ~/.kube/k3s-homelab.yaml
 chmod 600 ~/.kube/k3s-homelab.yaml
 export KUBECONFIG=~/.kube/k3s-homelab.yaml

--- a/k8s/apps/kube-vip.yaml
+++ b/k8s/apps/kube-vip.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-vip
+  namespace: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-succeeded.telegram: "-5248737533"
+    notifications.argoproj.io/subscribe.on-sync-failed.telegram: "-5248737533"
+    notifications.argoproj.io/subscribe.on-health-degraded.telegram: "-5248737533"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/byeich/homelab
+    targetRevision: kube-vip-28
+    path: k8s/apps/kube-vip
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/k8s/apps/kube-vip.yaml
+++ b/k8s/apps/kube-vip.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/byeich/homelab
-    targetRevision: kube-vip-28
+    targetRevision: main
     path: k8s/apps/kube-vip
   destination:
     server: https://kubernetes.default.svc

--- a/k8s/apps/kube-vip/daemonset.yaml
+++ b/k8s/apps/kube-vip/daemonset.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-vip
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: kube-vip
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-vip
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-vip
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: CriticalAddonsOnly
+          operator: Exists
+      hostNetwork: true
+      serviceAccountName: kube-vip
+      containers:
+        - name: kube-vip
+          image: ghcr.io/kube-vip/kube-vip:v0.8.7
+          imagePullPolicy: IfNotPresent
+          args:
+            - manager
+          env:
+            - name: vip_arp
+              value: "true"
+            - name: port
+              value: "6443"
+            - name: vip_interface
+              value: "eth0"
+            - name: vip_cidr
+              value: "32"
+            - name: cp_enable
+              value: "true"
+            - name: cp_namespace
+              value: "kube-system"
+            - name: vip_ddns
+              value: "false"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_leasename
+              value: "plndr-cp-lock"
+            - name: vip_leaseduration
+              value: "5"
+            - name: vip_renewdeadline
+              value: "3"
+            - name: vip_retryperiod
+              value: "1"
+            - name: address
+              value: "10.0.0.59"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+                - NET_RAW
+              drop:
+                - ALL

--- a/k8s/apps/kube-vip/rbac.yaml
+++ b/k8s/apps/kube-vip/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-vip
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:kube-vip-role
+rules:
+  - apiGroups: [""]
+    resources: ["services", "services/status", "nodes", "endpoints"]
+    verbs: ["list", "get", "watch", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["list", "get", "watch", "create", "update"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["list", "get", "watch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kube-vip-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-vip-role
+subjects:
+  - kind: ServiceAccount
+    name: kube-vip
+    namespace: kube-system

--- a/proxmox/ansible/group_vars/all/vars.yml
+++ b/proxmox/ansible/group_vars/all/vars.yml
@@ -3,3 +3,4 @@ dns_server: "10.0.0.53"
 # k3s cluster config — override k3s_token via vault
 k3s_version: ""
 k3s_api_port: 6443
+k3s_vip: "10.0.0.59"

--- a/proxmox/ansible/inventory.tftpl
+++ b/proxmox/ansible/inventory.tftpl
@@ -3,10 +3,10 @@ pihole1 ansible_host=${pihole_host} ansible_user=root ansible_ssh_private_key_fi
 
 [k3s-control]
 %{ for name, config in k3s_control_hosts ~}
-${name} ansible_host=${config.ip} ansible_user=debian
+${name} ansible_host=${config.ip} ansible_user=debian ansible_ssh_private_key_file=~/.ssh/k3s_cluster
 %{ endfor ~}
 
 [k3s-workers]
 %{ for name, config in k3s_worker_hosts ~}
-${name} ansible_host=${config.ip} ansible_user=debian
+${name} ansible_host=${config.ip} ansible_user=debian ansible_ssh_private_key_file=~/.ssh/k3s_cluster
 %{ endfor ~}

--- a/proxmox/ansible/roles/k3s_control/handlers/main.yml
+++ b/proxmox/ansible/roles/k3s_control/handlers/main.yml
@@ -1,4 +1,3 @@
 - name: Restart k3s
-  ansible.builtin.service:
-    name: k3s
-    state: restarted
+  ansible.builtin.command: systemctl --no-block restart k3s
+  changed_when: true

--- a/proxmox/ansible/roles/k3s_control/handlers/main.yml
+++ b/proxmox/ansible/roles/k3s_control/handlers/main.yml
@@ -1,3 +1,5 @@
 - name: Restart k3s
-  ansible.builtin.command: systemctl --no-block restart k3s
+  # --no-block required: k3s server is Type=notify and won't send READY until fully
+  # initialized. Without --no-block, systemctl restart hangs waiting for the signal.
+  ansible.builtin.command: systemctl --no-block restart k3s  # noqa: command-instead-of-module
   changed_when: true

--- a/proxmox/ansible/roles/k3s_control/tasks/main.yml
+++ b/proxmox/ansible/roles/k3s_control/tasks/main.yml
@@ -28,6 +28,8 @@
   when: inventory_hostname == groups['k3s-control'][0]
 
 - name: Install k3s server (join additional control nodes)  # noqa: command-instead-of-module
+  # Uses ctrl1's IP, not the VIP — kube-vip isn't deployed until after ctrl1 is up and
+  # ArgoCD has synced, so the VIP isn't available when ctrl2/ctrl3 join for the first time.
   ansible.builtin.shell: |
     set -euo pipefail
     curl -sfL https://get.k3s.io | K3S_TOKEN={{ k3s_token }} sh -s - server \

--- a/proxmox/ansible/roles/k3s_control/tasks/main.yml
+++ b/proxmox/ansible/roles/k3s_control/tasks/main.yml
@@ -3,6 +3,18 @@
     path: /usr/local/bin/k3s
   register: k3s_control_bin
 
+- name: Write k3s server config (TLS SANs for VIP)
+  ansible.builtin.copy:
+    dest: /etc/rancher/k3s/config.yaml
+    owner: root
+    group: root
+    mode: "0600"
+    content: |
+      tls-san:
+        - "{{ k3s_vip }}"
+        - "k8s-api.bkylab.net"
+  notify: Restart k3s
+
 # curl|sh is a supply-chain risk in production (no signature verification before execution).
 # Acceptable here because INSTALL_K3S_VERSION pins the exact release, and the k3s installer
 # is maintained by Rancher/SUSE with a strong release process. For production, download the

--- a/proxmox/ansible/roles/k3s_worker/handlers/main.yml
+++ b/proxmox/ansible/roles/k3s_worker/handlers/main.yml
@@ -1,3 +1,6 @@
 - name: Restart k3s-agent
-  ansible.builtin.command: systemctl --no-block restart k3s-agent
+  # --no-block required: k3s-agent is Type=notify and won't send READY until it connects
+  # to the API server. Without --no-block, systemctl restart hangs until the connection
+  # succeeds (which can take 30s+ if the agent retries on startup).
+  ansible.builtin.command: systemctl --no-block restart k3s-agent  # noqa: command-instead-of-module
   changed_when: true

--- a/proxmox/ansible/roles/k3s_worker/handlers/main.yml
+++ b/proxmox/ansible/roles/k3s_worker/handlers/main.yml
@@ -1,4 +1,3 @@
 - name: Restart k3s-agent
-  ansible.builtin.service:
-    name: k3s-agent
-    state: restarted
+  ansible.builtin.command: systemctl --no-block restart k3s-agent
+  changed_when: true

--- a/proxmox/ansible/roles/k3s_worker/tasks/main.yml
+++ b/proxmox/ansible/roles/k3s_worker/tasks/main.yml
@@ -3,12 +3,23 @@
     path: /usr/local/bin/k3s
   register: k3s_worker_bin
 
+# Update existing workers to point at the kube-vip VIP instead of ctrl1 directly.
+# k3s-agent reads K3S_URL from this env file on every start.
+# Run kube-vip DaemonSet via ArgoCD first so the VIP is live before restarting agents.
+- name: Set k3s server URL to VIP
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/system/k3s-agent.service.env
+    regexp: "^K3S_URL="
+    line: "K3S_URL='https://{{ k3s_vip }}:{{ k3s_api_port }}'"
+  when: k3s_worker_bin.stat.exists
+  notify: Restart k3s-agent
+
 - name: Install k3s agent  # noqa: command-instead-of-module
   ansible.builtin.shell: |
     set -euo pipefail
     curl -sfL https://get.k3s.io | \
       K3S_TOKEN={{ k3s_token }} \
-      K3S_URL=https://{{ hostvars[groups['k3s-control'][0]]['ansible_host'] }}:{{ k3s_api_port }} \
+      K3S_URL=https://{{ k3s_vip }}:{{ k3s_api_port }} \
       sh -
   args:
     executable: /bin/bash

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 CONTROL_NODE_IP="${K3S_CONTROL_IP:-10.0.0.60}"
+K3S_VIP="${K3S_VIP:-10.0.0.59}"
 SSH_KEY="${K3S_SSH_KEY:-$HOME/.ssh/k3s_cluster}"
 SSH_USER="debian"
 
@@ -77,10 +78,10 @@ section "Step 2: Configure kubectl"
 KUBECONFIG_PATH="$HOME/.kube/k3s-homelab.yaml"
 mkdir -p "$HOME/.kube"
 
-info "Copying kubeconfig from $CONTROL_NODE_IP..."
+info "Copying kubeconfig from $CONTROL_NODE_IP (pointing at VIP $K3S_VIP)..."
 ssh -i "$SSH_KEY" -o StrictHostKeyChecking=no "$SSH_USER@$CONTROL_NODE_IP" \
   "sudo cat /etc/rancher/k3s/k3s.yaml" \
-  | sed "s|https://127.0.0.1:6443|https://$CONTROL_NODE_IP:6443|g" \
+  | sed "s|https://127.0.0.1:6443|https://$K3S_VIP:6443|g" \
   > "$KUBECONFIG_PATH"
 chmod 600 "$KUBECONFIG_PATH"
 


### PR DESCRIPTION
## What

Deploy kube-vip as a DaemonSet on all three control plane nodes, advertising a floating VIP at `10.0.0.59` via ARP. Workers now join via the VIP instead of ctrl1 directly and losing any single control node leaves the API reachable and workers unaffected.

## Changes

- `k8s/apps/kube-vip/` — DaemonSet (ARP mode, eth0, VIP 10.0.0.59) + RBAC, pinned to control-plane nodes
- `k8s/apps/kube-vip.yaml` — ArgoCD Application
- `proxmox/ansible/group_vars/all/vars.yml` — `k3s_vip: "10.0.0.59"`
- `proxmox/ansible/roles/k3s_worker/` — updates `k3s-agent.service.env` on existing workers + uses VIP for new installs; `--no-block` restart to avoid `Type=notify` hang
- `proxmox/ansible/roles/k3s_control/` — writes `/etc/rancher/k3s/config.yaml` with TLS SANs for the VIP on all control nodes; same `--no-block` fix
- `proxmox/ansible/inventory.tftpl` — SSH key added for k3s nodes
- `docs/architecture.md` — updated diagram and HA note
- `docs/runbook-disaster-recovery.md` — kubeconfig command updated to use VIP
- `scripts/bootstrap.sh` — kubeconfig sed now points at VIP

## Tested

- Deployed kube-vip via ArgoCD, VIP came up on all 3 control nodes
- Rolled all 5 workers via Ansible — confirmed `K3S_URL=https://10.0.0.59:6443` on each
- TLS cert regenerated with VIP SAN — `kubectl` works via VIP with proper TLS
- Stopped ctrl1 k3s service — workers stayed Ready, API answered via VIP on ctrl2/ctrl3
- Brought ctrl1 back — rejoined clean

Closes #28