### PR TITLE
ci: add gitleaks, kube-linter, helm-render stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,58 @@ jobs:
             -ignore-filename-pattern '.*values\.yaml' \
             -summary \
             k8s/
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        env:
+          # renovate: datasource=github-releases depName=gitleaks/gitleaks
+          GITLEAKS_VERSION: "v8.30.1"
+        run: |
+          curl -sLo gitleaks.tar.gz \
+            https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz
+          tar xf gitleaks.tar.gz gitleaks
+          sudo mv gitleaks /usr/local/bin/
+      - name: Scan for secrets
+        run: gitleaks detect --source . --config .gitleaks.toml --redact --no-banner
+
+  kube-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install kube-linter
+        env:
+          # renovate: datasource=github-releases depName=stackrox/kube-linter
+          KUBE_LINTER_VERSION: "v0.8.3"
+        run: |
+          curl -sLo kube-linter.tar.gz \
+            https://github.com/stackrox/kube-linter/releases/download/${KUBE_LINTER_VERSION}/kube-linter-linux.tar.gz
+          tar xf kube-linter.tar.gz kube-linter
+          sudo mv kube-linter /usr/local/bin/
+      - name: Lint manifests
+        run: kube-linter lint k8s/ --config .kube-linter.yaml
+
+  helm-render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: azure/setup-helm@v5
+        with:
+          version: "v4.2.2"
+      - name: Render charts with repo values
+        run: |
+          set -euo pipefail
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add longhorn https://charts.longhorn.io
+          helm repo update
+          # chart versions are read from the ArgoCD app manifests so they can't drift
+          KPS_VER=$(grep -A1 'chart: kube-prometheus-stack' k8s/apps/kube-prometheus-stack.yaml | grep targetRevision | tr -d ' "' | cut -d: -f2)
+          helm template kps prometheus-community/kube-prometheus-stack --version "$KPS_VER" \
+            -f k8s/bootstrap/monitoring/values.yaml --namespace monitoring > /dev/null
+          LH_VER=$(grep -A1 'chart: longhorn' k8s/apps/infrastructure-longhorn.yaml | grep targetRevision | tr -d ' "' | cut -d: -f2)
+          helm template longhorn longhorn/longhorn --version "$LH_VER" \
+            -f k8s/infrastructure/longhorn/values.yaml --namespace longhorn-system > /dev/null

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# gitleaks config. Runs in CI over full git history.
+title = "homelab-gitleaks"
+
+[extend]
+useDefault = true
+
+# SealedSecrets are RSA-encrypted ciphertext, safe to commit. Skip them so the
+# generic-api-key rule doesn't flag the encrypted blobs.
+[[allowlists]]
+description = "sealed secrets are encrypted"
+paths = ['''k8s/.*sealed-secret\.yaml''']

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,8 @@
+# kube-linter config. Runs in CI against k8s/.
+# Default checks minus ones that don't fit a single-operator homelab.
+# Per-object exceptions use ignore-check.kube-linter.io annotations on the resource.
+checks:
+  exclude:
+    - "run-as-non-root"        # most app images run as root / non-numeric USER
+    - "no-read-only-root-fs"   # stateful apps need writable rootfs
+    - "no-anti-affinity"       # not required at this scale

--- a/k8s/apps/immich/machine-learning.yaml
+++ b/k8s/apps/immich/machine-learning.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: immich-machine-learning
   namespace: immich
+  annotations:
+    # probes hit :3003, which the container serves but doesn't declare as a port
+    ignore-check.kube-linter.io/liveness-port: "ml serves 3003"
+    ignore-check.kube-linter.io/readiness-port: "ml serves 3003"
 spec:
   replicas: 1
   strategy:

--- a/k8s/apps/kube-vip/daemonset.yaml
+++ b/k8s/apps/kube-vip/daemonset.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: kube-system
   labels:
     app.kubernetes.io/name: kube-vip
+  annotations:
+    # host network and NET_RAW are required to advertise the VIP via ARP
+    ignore-check.kube-linter.io/host-network: "required for VIP ARP"
+    ignore-check.kube-linter.io/drop-net-raw-capability: "required for VIP ARP"
 spec:
   selector:
     matchLabels:

--- a/k8s/apps/vaultwarden/backup-cronjob.yaml
+++ b/k8s/apps/vaultwarden/backup-cronjob.yaml
@@ -15,6 +15,13 @@ spec:
           containers:
             - name: backup
               image: curlimages/curl:8.21.0
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
               command:
                 - /bin/sh
                 - -c

--- a/k8s/apps/vaultwarden/deployment.yaml
+++ b/k8s/apps/vaultwarden/deployment.yaml
@@ -20,6 +20,13 @@ spec:
         - name: fix-data-ownership
           image: busybox:1.38
           command: ["sh", "-c", "chown -R 0:0 /data && chmod -R u+rw /data"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
- gitleaks: secret scanning over full git history, SealedSecrets allowlisted
- kube-linter: k8s security lint, tuned config plus ignore annotations
- helm-render: template kube-prometheus-stack and longhorn against repo values, chart versions read from the ArgoCD app manifests to prevent drift
- add resources to the vaultwarden backup cronjob and fix-data-ownership init container (findings from kube-linter)