### PR TITLE
Add runner for end-to-end test execution

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,7 @@ jobs:
     # secrets and tofu state live in the runner home, checkout cleans the workspace
     env:
       TF_CLI_ARGS_init: -backend-config=path=/home/runner/.homelab/test-env.tfstate
+      TF_PLUGIN_CACHE_DIR: /home/runner/.homelab/plugin-cache
       TEST_ENV_VAR_FILE: /home/runner/.homelab/variables.auto.tfvars
       ANSIBLE_VAULT_PASSWORD_FILE: /home/runner/.homelab/.vault_pass
       K3S_SSH_KEY: /home/runner/.ssh/k3s_cluster

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,12 @@ jobs:
   e2e:
     runs-on: [self-hosted, homelab]
     timeout-minutes: 30
+    # secrets and tofu state live in the runner home, checkout cleans the workspace
+    env:
+      TF_CLI_ARGS_init: -backend-config=path=/home/runner/.homelab/test-env.tfstate
+      TEST_ENV_VAR_FILE: /home/runner/.homelab/variables.auto.tfvars
+      ANSIBLE_VAULT_PASSWORD_FILE: /home/runner/.homelab/.vault_pass
+      K3S_SSH_KEY: /home/runner/.ssh/k3s_cluster
     steps:
       - uses: actions/checkout@v7
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ cd ../.. && ./scripts/test-env.sh verify   # all nodes joined and Ready
 ./scripts/test-env.sh down              # tofu destroy
 ```
 
-`.github/workflows/e2e.yml` runs the same sequence on a self-hosted runner, manual
-trigger only (`workflow_dispatch`): Renovate PRs never spin up VMs, and fork PRs cannot
-run code on the LAN runner.
+`.github/workflows/e2e.yml` runs the same sequence on the self-hosted runner (LXC 304,
+provisioned by `playbooks/gh_runner.yml`), manual trigger only (`workflow_dispatch`):
+Renovate PRs never spin up VMs, and fork PRs cannot run code on the LAN runner. The run
+needs ~5GB free RAM on the homelab node.

--- a/proxmox/ansible/inventory.tftpl
+++ b/proxmox/ansible/inventory.tftpl
@@ -1,6 +1,13 @@
 [pihole]
 pihole1 ansible_host=${pihole_host} ansible_user=root ansible_ssh_private_key_file=~/.ssh/id_ed25519
 
+[gh_runner]
+gh-runner ansible_host=${gh_runner_host} ansible_user=root ansible_ssh_private_key_file=~/.ssh/homelab
+
+[lxc_host:children]
+pihole
+gh_runner
+
 [k3s-control]
 %{ for name, config in k3s_control_hosts ~}
 ${name} ansible_host=${config.ip} ansible_user=debian ansible_ssh_private_key_file=~/.ssh/k3s_cluster

--- a/proxmox/ansible/playbooks/gh_runner.yml
+++ b/proxmox/ansible/playbooks/gh_runner.yml
@@ -1,0 +1,5 @@
+- name: GitHub Actions runner for e2e workflow
+  hosts: gh_runner
+  become: true
+  roles:
+    - gh_runner

--- a/proxmox/ansible/roles/gh_runner/defaults/main.yml
+++ b/proxmox/ansible/roles/gh_runner/defaults/main.yml
@@ -2,6 +2,9 @@
 gh_runner_version: "2.335.1"
 # renovate: datasource=github-releases depName=opentofu/opentofu
 gh_runner_tofu_version: "1.12.3"
+# 2.19 is the newest core that runs on bookworm python 3.11
+# renovate: datasource=pypi depName=ansible-core
+gh_runner_ansible_core_version: "2.19.11"
 gh_runner_repo: "byeich/homelab"
 gh_runner_user: "runner"
 gh_runner_home: "/home/runner"

--- a/proxmox/ansible/roles/gh_runner/defaults/main.yml
+++ b/proxmox/ansible/roles/gh_runner/defaults/main.yml
@@ -1,0 +1,8 @@
+# renovate: datasource=github-releases depName=actions/runner
+gh_runner_version: "2.335.1"
+# renovate: datasource=github-releases depName=opentofu/opentofu
+gh_runner_tofu_version: "1.12.3"
+gh_runner_repo: "byeich/homelab"
+gh_runner_user: "runner"
+gh_runner_home: "/home/runner"
+gh_runner_labels: "homelab"

--- a/proxmox/ansible/roles/gh_runner/tasks/main.yml
+++ b/proxmox/ansible/roles/gh_runner/tasks/main.yml
@@ -35,6 +35,7 @@
     mode: "0700"
   loop:
     - "{{ gh_runner_home }}/.homelab"
+    - "{{ gh_runner_home }}/.homelab/plugin-cache"
     - "{{ gh_runner_home }}/.ssh"
     - "{{ gh_runner_home }}/actions-runner"
 

--- a/proxmox/ansible/roles/gh_runner/tasks/main.yml
+++ b/proxmox/ansible/roles/gh_runner/tasks/main.yml
@@ -8,9 +8,39 @@
       - unzip
       - acl
       - python3
-      - ansible
+      - python3-venv
     state: present
     update_cache: true
+
+# apt ansible is core 2.14, too old for the pinned collections
+- name: Remove apt ansible
+  ansible.builtin.apt:
+    name:
+      - ansible
+      - ansible-core
+    state: absent
+
+- name: Install ansible-core in venv
+  ansible.builtin.pip:
+    name: "ansible-core=={{ gh_runner_ansible_core_version }}"
+    virtualenv: /opt/ansible
+    virtualenv_command: python3 -m venv
+
+- name: Link ansible binaries
+  ansible.builtin.file:
+    src: "/opt/ansible/bin/{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+    state: link
+  loop:
+    - ansible
+    - ansible-playbook
+    - ansible-galaxy
+
+- name: Check tofu version
+  ansible.builtin.command: /usr/local/bin/tofu --version
+  register: gh_runner_tofu_current
+  failed_when: false
+  changed_when: false
 
 - name: Install tofu binary
   ansible.builtin.unarchive:
@@ -18,7 +48,7 @@
     dest: /usr/local/bin
     remote_src: true
     include: [tofu]
-    creates: /usr/local/bin/tofu
+  when: ("v" ~ gh_runner_tofu_version) not in gh_runner_tofu_current.stdout | default("")
 
 - name: Create runner user
   ansible.builtin.user:
@@ -124,4 +154,3 @@
   args:
     chdir: "{{ gh_runner_home }}/actions-runner"
   changed_when: true
-  failed_when: false

--- a/proxmox/ansible/roles/gh_runner/tasks/main.yml
+++ b/proxmox/ansible/roles/gh_runner/tasks/main.yml
@@ -1,0 +1,126 @@
+- name: Install packages
+  ansible.builtin.apt:
+    name:
+      - curl
+      - git
+      - jq
+      - tar
+      - unzip
+      - acl
+      - python3
+      - ansible
+    state: present
+    update_cache: true
+
+- name: Install tofu binary
+  ansible.builtin.unarchive:
+    src: "https://github.com/opentofu/opentofu/releases/download/v{{ gh_runner_tofu_version }}/tofu_{{ gh_runner_tofu_version }}_linux_amd64.zip"
+    dest: /usr/local/bin
+    remote_src: true
+    include: [tofu]
+    creates: /usr/local/bin/tofu
+
+- name: Create runner user
+  ansible.builtin.user:
+    name: "{{ gh_runner_user }}"
+    home: "{{ gh_runner_home }}"
+    shell: /bin/bash
+
+- name: Create runner dirs
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ gh_runner_user }}"
+    group: "{{ gh_runner_user }}"
+    mode: "0700"
+  loop:
+    - "{{ gh_runner_home }}/.homelab"
+    - "{{ gh_runner_home }}/.ssh"
+    - "{{ gh_runner_home }}/actions-runner"
+
+# secrets live outside the workspace, actions/checkout cleans it every run
+- name: Copy secrets from controller
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ gh_runner_user }}"
+    group: "{{ gh_runner_user }}"
+    mode: "0600"
+  loop:
+    - src: "{{ playbook_dir }}/../../tofu/variables.auto.tfvars"
+      dest: "{{ gh_runner_home }}/.homelab/variables.auto.tfvars"
+    - src: "{{ playbook_dir }}/../.vault_pass"
+      dest: "{{ gh_runner_home }}/.homelab/.vault_pass"
+    - src: "~/.ssh/k3s_cluster"
+      dest: "{{ gh_runner_home }}/.ssh/k3s_cluster"
+    - src: "~/.ssh/k3s_cluster.pub"
+      dest: "{{ gh_runner_home }}/.ssh/k3s_cluster.pub"
+
+- name: Copy collection requirements
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../requirements.yml"
+    dest: "{{ gh_runner_home }}/.homelab/requirements.yml"
+    owner: "{{ gh_runner_user }}"
+    group: "{{ gh_runner_user }}"
+    mode: "0644"
+
+- name: Install ansible collections for runner user
+  ansible.builtin.command: ansible-galaxy collection install -r {{ gh_runner_home }}/.homelab/requirements.yml
+  become: true
+  become_user: "{{ gh_runner_user }}"
+  args:
+    creates: "{{ gh_runner_home }}/.ansible/collections/ansible_collections/community"
+
+- name: Download actions runner
+  ansible.builtin.unarchive:
+    src: "https://github.com/actions/runner/releases/download/v{{ gh_runner_version }}/actions-runner-linux-x64-{{ gh_runner_version }}.tar.gz"
+    dest: "{{ gh_runner_home }}/actions-runner"
+    remote_src: true
+    owner: "{{ gh_runner_user }}"
+    group: "{{ gh_runner_user }}"
+    creates: "{{ gh_runner_home }}/actions-runner/config.sh"
+
+- name: Install runner dependencies
+  ansible.builtin.command: ./bin/installdependencies.sh
+  args:
+    chdir: "{{ gh_runner_home }}/actions-runner"
+    creates: /usr/lib/x86_64-linux-gnu/libicu*
+
+- name: Check if runner is registered
+  ansible.builtin.stat:
+    path: "{{ gh_runner_home }}/actions-runner/.runner"
+  register: gh_runner_registered
+
+- name: Get registration token
+  ansible.builtin.command: gh api -X POST repos/{{ gh_runner_repo }}/actions/runners/registration-token --jq .token
+  delegate_to: localhost
+  become: false
+  register: gh_runner_token
+  changed_when: false
+  when: not gh_runner_registered.stat.exists
+
+- name: Register runner
+  ansible.builtin.command: >
+    ./config.sh --url https://github.com/{{ gh_runner_repo }}
+    --token {{ gh_runner_token.stdout }}
+    --name gh-runner --labels {{ gh_runner_labels }}
+    --unattended --replace
+  args:
+    chdir: "{{ gh_runner_home }}/actions-runner"
+  become: true
+  become_user: "{{ gh_runner_user }}"
+  when: not gh_runner_registered.stat.exists
+  changed_when: true
+
+- name: Install runner service
+  ansible.builtin.command: ./svc.sh install {{ gh_runner_user }}
+  args:
+    chdir: "{{ gh_runner_home }}/actions-runner"
+    creates: /etc/systemd/system/actions.runner.*.service
+
+- name: Start runner service
+  ansible.builtin.command: ./svc.sh start
+  args:
+    chdir: "{{ gh_runner_home }}/actions-runner"
+  changed_when: true
+  failed_when: false

--- a/proxmox/ansible/roles/k3s_common/tasks/main.yml
+++ b/proxmox/ansible/roles/k3s_common/tasks/main.yml
@@ -6,6 +6,11 @@
       nameserver 1.1.1.1
     mode: "0644"
 
+# first-boot unattended-upgrades can replace systemd mid-run, breaking systemctl calls
+- name: Wait for automatic upgrades to finish
+  ansible.builtin.command: systemd-run --property=After=apt-daily.service --property=After=apt-daily-upgrade.service --wait /bin/true
+  changed_when: false
+
 - name: Update apt cache and install base packages
   ansible.builtin.apt:
     update_cache: true
@@ -15,11 +20,18 @@
       - ca-certificates
       - open-iscsi
       - nfs-common
+      - qemu-guest-agent
     state: present
 
 - name: Enable and start iscsid
   ansible.builtin.systemd:
     name: iscsid
+    enabled: true
+    state: started
+
+- name: Enable and start qemu-guest-agent
+  ansible.builtin.systemd:
+    name: qemu-guest-agent
     enabled: true
     state: started
 

--- a/proxmox/tofu/main.tf
+++ b/proxmox/tofu/main.tf
@@ -13,7 +13,8 @@ locals {
   }
 
   containers = {
-    pihole = { vm_id = 303, memory = 512, cores = 1, ip = "10.0.0.53/24" }
+    pihole    = { vm_id = 303, memory = 512, cores = 1, ip = "10.0.0.53/24" }
+    gh-runner = { vm_id = 304, memory = 1024, cores = 2, ip = "10.0.0.55/24", tags = ["ci"] }
   }
 
   # K3s VMs
@@ -37,6 +38,7 @@ resource "proxmox_virtual_environment_container" "svc" {
   for_each  = local.containers
   node_name = local.defaults.node
   vm_id     = each.value.vm_id
+  tags      = concat(["opentofu", "debian"], lookup(each.value, "tags", []))
 
   operating_system {
     template_file_id = local.defaults.tmpl_id
@@ -175,6 +177,7 @@ locals {
 resource "local_file" "ansible_inventory" {
   content = templatefile("${path.module}/../ansible/inventory.tftpl", {
     pihole_host       = split("/", local.containers["pihole"].ip)[0]
+    gh_runner_host    = split("/", local.containers["gh-runner"].ip)[0]
     k3s_control_hosts = local.k3s_control_hosts
     k3s_worker_hosts  = local.k3s_worker_hosts
   })

--- a/proxmox/tofu/test-env/main.tf
+++ b/proxmox/tofu/test-env/main.tf
@@ -86,6 +86,9 @@ resource "proxmox_virtual_environment_vm" "k3s_test_vms" {
   }
 
   started = true
+
+  # force stop, teardown must not depend on guest agent state
+  stop_on_destroy = true
 }
 
 locals {

--- a/proxmox/tofu/test-env/provider.tf
+++ b/proxmox/tofu/test-env/provider.tf
@@ -10,6 +10,7 @@ terraform {
     }
   }
   # local state on purpose, must never touch the B2 prod state
+  backend "local" {}
 }
 
 provider "proxmox" {

--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\w+: \"(?<currentValue>[^\"]+)\""
       ],
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,13 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\nk3s_version: \"(?<currentValue>[^\"]+)\""
       ]
+    },
+    {
+      "fileMatch": ["^proxmox/ansible/roles/gh_runner/defaults/main\\.yml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\w+: \"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ]
 }

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TF_DIR="$REPO_ROOT/proxmox/tofu/test-env"
 TF="tofu -chdir=$TF_DIR"
-VAR_FILE="../variables.auto.tfvars"
+VAR_FILE="${TEST_ENV_VAR_FILE:-../variables.auto.tfvars}"
 SSH_KEY="${K3S_SSH_KEY:-$HOME/.ssh/k3s_cluster}"
 
 tf_init() { $TF init -input=false >/dev/null; }


### PR DESCRIPTION
Adding gh-runner LXC to production tofu config, gh runner Ansible role that creates the runner from scratch,configures it, and registers it.

Also had to update the `k3s_common` role to prevent a race between the automatic upgrades running and installing packages.

This PR also Closes #59.

Link to Action successfully creating/deploying/destroying test env:
https://github.com/byeich/homelab/actions/runs/28760264099/job/85274266993


